### PR TITLE
Enable execution to scroll automatically to the bottom

### DIFF
--- a/Scenes/Execution.gd
+++ b/Scenes/Execution.gd
@@ -152,9 +152,9 @@ func go_back() -> void:
 func _exit_tree() -> void:
 	Data.reset_current_routine()
 
+	if task_in_progress:
+		current_task._cleanup()
+
 func _process(_delta: float) -> void:
     self.scroll_vertical = self.get_v_scroll_bar().max_value
 
-	
-	if task_in_progress:
-		current_task._cleanup()


### PR DESCRIPTION
This PR uses _process to auto scroll the execution scene to the bottom to keep up with the output.

Please consider this as one of my first submissions for this project. I hope to make many more contributions as I can see a lot of value in this program.
